### PR TITLE
fix: update ipfs-unixfs dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "files-from-path",
       "version": "0.2.0",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
@@ -15,7 +14,7 @@
       "devDependencies": {
         "@types/node": "^16.3.2",
         "ava": "^3.15.0",
-        "ipfs-unixfs": "^5.0.0",
+        "ipfs-unixfs": "^6.0.5",
         "ipjs": "^5.0.3",
         "standard": "^16.0.3",
         "typescript": "^4.3.5"
@@ -2611,9 +2610,9 @@
       }
     },
     "node_modules/ipfs-unixfs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-5.0.0.tgz",
-      "integrity": "sha512-6FpBtsxB/9R7o7LGmSMaIoYkWO/cK+JYcj22QYIZaiA5dlk28Dvqme18bA43A7UKEc0M8I7mwD92ZXrlhJ/C7Q==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.5.tgz",
+      "integrity": "sha512-D8Z3EsegLxOBc2L8oMyZw/FRUDQG0ZZAaBRfzMrRsGnj7RFI7OlV1hU54aMeDxFYFviKNnUdsyEFI2zUWmgGvw==",
       "dev": true,
       "dependencies": {
         "err-code": "^3.0.1",
@@ -2621,7 +2620,7 @@
       },
       "engines": {
         "node": ">=14.0.0",
-        "npm": ">=7.0.0"
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/ipjs": {
@@ -7378,9 +7377,9 @@
       }
     },
     "ipfs-unixfs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-5.0.0.tgz",
-      "integrity": "sha512-6FpBtsxB/9R7o7LGmSMaIoYkWO/cK+JYcj22QYIZaiA5dlk28Dvqme18bA43A7UKEc0M8I7mwD92ZXrlhJ/C7Q==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.5.tgz",
+      "integrity": "sha512-D8Z3EsegLxOBc2L8oMyZw/FRUDQG0ZZAaBRfzMrRsGnj7RFI7OlV1hU54aMeDxFYFviKNnUdsyEFI2zUWmgGvw==",
       "dev": true,
       "requires": {
         "err-code": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@types/node": "^16.3.2",
     "ava": "^3.15.0",
-    "ipfs-unixfs": "^5.0.0",
+    "ipfs-unixfs": "^6.0.5",
     "ipjs": "^5.0.3",
     "standard": "^16.0.3",
     "typescript": "^4.3.5"


### PR DESCRIPTION
This fixes the import path used in the built types @ `dist/types/index.d.ts`. Switches to:

```ts
mtime?: import("ipfs-unixfs/types/src/types").MtimeLike | undefined;
```

from (old v5):

```ts
mtime?: import("ipfs-unixfs/dist/src/types").MtimeLike | undefined;
```

Since this is a `devDependency` it relies on the version installed by the module that uses it. In web3.storage we're using v6. Maybe it should move to `dependencies`? IDK typescript 🤷‍♂️.