### PR TITLE
fix: file object stream type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ import errCode from 'err-code'
  *
  * @typedef FileObject
  * @property {string} name
- * @property {AsyncIterator<Buffer>} stream
+ * @property {() => fs.ReadStream} stream
  */
 
 /**
@@ -36,7 +36,6 @@ export async function getFilesFromPath (paths, options) {
     files.push(file)
   }
 
-  // @ts-ignore
   return files
 }
 


### PR DESCRIPTION
Stream type is a function returning fs.readStream

Closes https://github.com/web3-storage/web3.storage/issues/830