### PR TITLE
chore: release v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "files-from-path",
-  "version": "0.2.6",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "files-from-path",
-      "version": "0.2.6",
+      "version": "1.0.0",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "graceful-fs": "^4.2.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "files-from-path",
-  "version": "0.2.6",
+  "version": "1.0.0",
   "description": "Expand paths to file-like objects with name, readable stream and size.",
   "main": "src/index.js",
   "types": "./types/index.d.ts",


### PR DESCRIPTION
BREAKING CHANGE: API, behavior and return types have changed. The module now only exports one function `filesFromPaths` which returns an array of file-like objects. The stream returned by `stream()` in these objects is now a web stream ([`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)). File names now have their common prefix stripped automatically. Finally, the minimum Node.js version has increased from 14 to 18 (the current LTS) because of we use `Readable.toWeb()`.