### PR TITLE
fix: stable ordering of files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,17 +7,17 @@
     "": {
       "name": "files-from-path",
       "version": "1.0.0",
-      "license": "(Apache-2.0 AND MIT)",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "graceful-fs": "^4.2.10"
       },
       "devDependencies": {
         "@types/graceful-fs": "^4.1.6",
-        "@types/node": "^18.15.1",
+        "@types/node": "^20.9.0",
         "ava": "^5.2.0",
         "ipjs": "^5.0.3",
         "standard": "^17.0.0",
-        "typescript": "^4.9.5",
+        "typescript": "^5.2.2",
         "unlimited": "^1.2.2"
       },
       "engines": {
@@ -191,10 +191,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.15.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.1.tgz",
-      "integrity": "sha512-U2TWca8AeHSmbpi314QBESRk7oPjSZjDsR+c+H4ECC1l+kFgpZf8Ydhv3SJpPy51VyZHHqxlb6mTTqYNNRVAIw==",
-      "dev": true
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/acorn": {
       "version": "8.8.2",
@@ -4233,16 +4236,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -4259,6 +4262,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unlimited": {
       "version": "1.2.2",
@@ -4706,10 +4715,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.15.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.1.tgz",
-      "integrity": "sha512-U2TWca8AeHSmbpi314QBESRk7oPjSZjDsR+c+H4ECC1l+kFgpZf8Ydhv3SJpPy51VyZHHqxlb6mTTqYNNRVAIw==",
-      "dev": true
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "acorn": {
       "version": "8.8.2",
@@ -7547,9 +7559,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "unbox-primitive": {
@@ -7563,6 +7575,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "unlimited": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   },
   "devDependencies": {
     "@types/graceful-fs": "^4.1.6",
-    "@types/node": "^18.15.1",
+    "@types/node": "^20.9.0",
     "ava": "^5.2.0",
     "ipjs": "^5.0.3",
     "standard": "^17.0.0",
-    "typescript": "^4.9.5",
+    "typescript": "^5.2.2",
     "unlimited": "^1.2.2"
   },
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,45 @@
-import fs from 'graceful-fs'
+import gracefulfs from 'graceful-fs'
 import { promisify } from 'util'
 import path from 'path'
 import { Readable } from 'stream'
 
-/** @typedef {Pick<File, 'stream'|'name'|'size'>} FileLike */
+/**
+ * @typedef {Pick<File, 'stream'|'name'|'size'>} FileLike
+ * @typedef {{
+ *   name: string
+ *   isFile: () => boolean
+ *   isDirectory: () => boolean
+ * }} Dirent
+ * @typedef {{
+ *   readdir: (path: string, options: { withFileTypes: true }) => Promise<Dirent[]>
+ * }} DirReader
+ * @typedef {{
+ *   size: number
+ *   isFile: () => boolean
+ *   isDirectory: () => boolean
+ * }} Stats
+ * @typedef {{ stat: (path: string) => Promise<Stats> }} StatGetter
+ * @typedef {{
+ *   createReadStream: (path: string) => import('node:fs').ReadStream
+ *   promises: DirReader & StatGetter
+ * }} FileSystem
+ */
 
-// https://github.com/isaacs/node-graceful-fs/issues/160
-const fsStat = promisify(fs.stat)
-const fsReaddir = promisify(fs.readdir)
+const defaultfs = {
+  createReadStream: gracefulfs.createReadStream,
+  promises: {
+    // https://github.com/isaacs/node-graceful-fs/issues/160
+    stat: promisify(gracefulfs.stat),
+    readdir: promisify(gracefulfs.readdir)
+  }
+}
 
 /**
  * @param {Iterable<string>} paths
  * @param {object} [options]
  * @param {boolean} [options.hidden]
+ * @param {boolean} [options.sort] Sort by path. Default: true.
+ * @param {FileSystem} [options.fs] Custom FileSystem implementation.
  * @returns {Promise<FileLike[]>}
  */
 export async function filesFromPaths (paths, options) {
@@ -36,18 +63,23 @@ export async function filesFromPaths (paths, options) {
     }
   }
   const commonPath = `${(commonParts ?? []).join('/')}/`
-  return files.map(f => ({ ...f, name: f.name.slice(commonPath.length) }))
+  const commonPathFiles = files.map(f => ({ ...f, name: f.name.slice(commonPath.length) }))
+  return options?.sort == null || options?.sort === true
+    ? commonPathFiles.sort((a, b) => a.name === b.name ? 0 : a.name > b.name ? 1 : -1)
+    : commonPathFiles
 }
 
 /**
  * @param {string} filepath
  * @param {object} [options]
  * @param {boolean} [options.hidden]
+ * @param {FileSystem} [options.fs] Custom FileSystem implementation.
  * @returns {AsyncIterableIterator<FileLike>}
  */
-async function * filesFromPath (filepath, options = {}) {
+async function * filesFromPath (filepath, options) {
   filepath = path.resolve(filepath)
-  const hidden = options.hidden ?? false
+  const fs = options?.fs ?? defaultfs
+  const hidden = options?.hidden ?? false
 
   /** @param {string} filepath */
   const filter = filepath => {
@@ -56,7 +88,7 @@ async function * filesFromPath (filepath, options = {}) {
   }
 
   const name = filepath
-  const stat = await fsStat(name)
+  const stat = await fs.promises.stat(name)
 
   if (!filter(name)) {
     return
@@ -64,19 +96,22 @@ async function * filesFromPath (filepath, options = {}) {
 
   if (stat.isFile()) {
     // @ts-expect-error node web stream not type compatible with web stream
-    yield { name, stream: () => Readable.toWeb(fs.createReadStream(name)), size: stat.size }
+    yield { name, stream: () => Readable.toWeb(defaultfs.createReadStream(name)), size: stat.size }
   } else if (stat.isDirectory()) {
-    yield * filesFromDir(name, filter)
+    yield * filesFromDir(name, filter, options)
   }
 }
 
 /**
  * @param {string} dir
  * @param {(name: string) => boolean} filter
+ * @param {object} [options]
+ * @param {FileSystem} [options.fs] Custom FileSystem implementation.
  * @returns {AsyncIterableIterator<FileLike>}
  */
-async function * filesFromDir (dir, filter) {
-  const entries = await fsReaddir(path.join(dir), { withFileTypes: true })
+async function * filesFromDir (dir, filter, options) {
+  const fs = options?.fs ?? defaultfs
+  const entries = await fs.promises.readdir(path.join(dir), { withFileTypes: true })
   for (const entry of entries) {
     if (!filter(entry.name)) {
       continue
@@ -84,7 +119,7 @@ async function * filesFromDir (dir, filter) {
 
     if (entry.isFile()) {
       const name = path.join(dir, entry.name)
-      const { size } = await fsStat(name)
+      const { size } = await fs.promises.stat(name)
       // @ts-expect-error node web stream not type compatible with web stream
       yield { name, stream: () => Readable.toWeb(fs.createReadStream(name)), size }
     } else if (entry.isDirectory()) {

--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ async function * filesFromPath (filepath, options) {
 
   if (stat.isFile()) {
     // @ts-expect-error node web stream not type compatible with web stream
-    yield { name, stream: () => Readable.toWeb(defaultfs.createReadStream(name)), size: stat.size }
+    yield { name, stream: () => Readable.toWeb(fs.createReadStream(name)), size: stat.size }
   } else if (stat.isDirectory()) {
     yield * filesFromDir(name, filter, options)
   }

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -63,6 +63,28 @@ test('allows read of more files than ulimit maxfiles', async t => {
   }
 })
 
+test('uses custom fs implementation', async t => {
+  // it uses graceful-fs by default so passing node:fs is legit test
+  const files = await filesFromPaths([`${process.cwd()}/test/fixtures`], { fs })
+  t.true(files.length === 3)
+})
+
+test('sorts by path', async t => {
+  const paths = ['dir/file2.txt', 'empty.car', 'file.txt']
+  /** @param {string} name */
+  const toDirEnt = name => ({ name, isFile: () => true, isDirectory: () => false })
+  const files = await filesFromPaths([`${process.cwd()}/test/fixtures`], {
+    fs: {
+      createReadStream: fs.createReadStream,
+      promises: {
+        stat: fs.promises.stat,
+        readdir: async () => [...paths].reverse().map(toDirEnt)
+      }
+    }
+  })
+  t.deepEqual(files.map(f => f.name), paths)
+})
+
 /**
  * @param {number} n
  */


### PR DESCRIPTION
Apparently on windows `fs.readdir` does not provide a sorted list of file entries. This PR fixes the `filesFromPaths` to always provide a stable ordering of files by default. This can be disabled by passing `sort: false` in the options.