### PR TITLE
fix: handle paths as string param

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ const defaultfs = {
 }
 
 /**
- * @param {Iterable<string>} paths
+ * @param {string | Iterable<string>} paths
  * @param {object} [options]
  * @param {boolean} [options.hidden]
  * @param {boolean} [options.sort] Sort by path. Default: true.
@@ -43,6 +43,9 @@ const defaultfs = {
  * @returns {Promise<FileLike[]>}
  */
 export async function filesFromPaths (paths, options) {
+  if (typeof paths === 'string') {
+    paths = [paths]
+  }
   /** @type {string[]|undefined} */
   let commonParts
   const files = []

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -7,10 +7,14 @@ import fs from 'fs'
 import unlimited from 'unlimited'
 import { filesFromPaths } from '../src/index.js'
 
-test('gets files from node_modules', async (t) => {
-  const files = await filesFromPaths(['node_modules'])
-  t.log(`${files.length} files in node_modules`)
-  t.true(files.length > 1)
+test('gets files from path string ', async (t) => {
+  const files = await filesFromPaths('test/fixtures/dir')
+  t.is(files.length, 1)
+})
+
+test('gets files from path array', async (t) => {
+  const files = await filesFromPaths(['test/fixtures/dir'])
+  t.is(files.length, 1)
 })
 
 test('includes file size', async (t) => {


### PR DESCRIPTION
handle the case where user passes paths as a string, otherwise we iterate the characters of the string, and if any of them are `/` we initiate a full discan from the root.

fix: https://github.com/web3-storage/files-from-path/issues/28

License: MIT