### PR TITLE
chore: release from ci and add `--provenance` for verifiable builds!

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,19 +44,22 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
           release-type: node
           package-name: files-from-path
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
+      - uses: actions/setup-node@v4
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          node-version: 18
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+        if: ${{ steps.release.outputs.release_created }}
       - run: npm publish --provenance
+        if: ${{ steps.release.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: ${{ steps.release.outputs.release_created }}
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,14 +11,15 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: ${{matrix.node}}
-      - run: npm install
-      - run: npm run  build
-      - name: Lint
-        run: npm run lint
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: npm run lint
+
   test:
     needs: check
     runs-on: ${{ matrix.os }}
@@ -26,12 +27,36 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [18, 19]
+        node: [18, 20]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node}}
-      - run: npm install
-      - name: Unit tests
-        run: npm run test
+      - run: npm ci
+      - run: npm run test
+
+  release:
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: files-from-path
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
+      - run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: ${{ steps.release.outputs.release_created }}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ It returns an _array_ of file-like objects in the form:
 
 ## Releasing
 
-You can publish by either running npm publish in the dist directory or using npx ipjs publish.
+Releasing to npm is done via [`release-please`](https://github.com/googleapis/release-please). A Release PR will be opened with a CHANGELOG update in after a PR is merged to main. Merging the release PR will publish the new version to npm.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "author": "vasco-santos",
   "license": "Apache-2.0 OR MIT",
   "scripts": {
+    "prepare": "npm run build",
     "build": "npm run build:js && npm run build:types",
     "build:js": "ipjs build --main && npm run build:copy",
     "build:copy": "cp -a tsconfig.json src test dist/ ",


### PR DESCRIPTION
- add `release-please` to automate publishing to npm from ci
- add `--provenance` flag to npm publish to capture to assert this package was built in a veriable way.


see: https://github.blog/2023-04-19-introducing-npm-package-provenance/
see: https://docs.npmjs.com/generating-provenance-statements

License: MIT