### PR TITLE
chore: allow release-plz to open changelog PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,9 @@ jobs:
           node-version: 18
           cache: 'npm'
       - run: npm ci
-      - run: npm run build
       - run: npm run lint
 
   test:
-    needs: check
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -38,10 +36,14 @@ jobs:
 
   release:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    needs: test
+    needs: 
+      - test
+      - check
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: google-github-actions/release-please-action@v3


### PR DESCRIPTION
- grant permissions to open PRs and add changelogs, needed for release-please to do the thing
- run check and test in parallel. no need to have tests wait for lints.

hoping this fixes the error seen here where release please is unable to open a PR
https://github.com/web3-storage/files-from-path/actions/runs/6932934315/job/18858238223

see: https://github.com/google-github-actions/release-please-action/issues/709

License: MIT