### PR TITLE
feat(filefrompath): filter results with function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,17 +124,17 @@ async function * filesFromDir (dir, filter, options) {
   const fs = options?.fs ?? defaultfs
   const entries = await fs.promises.readdir(path.join(dir), { withFileTypes: true })
   for (const entry of entries) {
-    if (!filter(entry.name)) {
+    const name = path.join(dir, entry.name)
+    if (!filter(name)) {
       continue
     }
 
     if (entry.isFile()) {
-      const name = path.join(dir, entry.name)
       const { size } = await fs.promises.stat(name)
       // @ts-expect-error node web stream not type compatible with web stream
       yield { name, stream: () => Readable.toWeb(fs.createReadStream(name)), size }
     } else if (entry.isDirectory()) {
-      yield * filesFromDir(path.join(dir, entry.name), filter)
+      yield * filesFromDir(name, filter)
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ const defaultfs = {
  * @param {boolean} [options.hidden]
  * @param {boolean} [options.sort] Sort by path. Default: true.
  * @param {FileSystem} [options.fs] Custom FileSystem implementation.
+ * @param {(fullPath: string) => boolean} [options.filter] filter discovered files
  * @returns {Promise<FileLike[]>}
  */
 export async function filesFromPaths (paths, options) {
@@ -83,6 +84,7 @@ export async function filesFromPaths (paths, options) {
  * @param {object} [options]
  * @param {boolean} [options.hidden]
  * @param {FileSystem} [options.fs] Custom FileSystem implementation.
+ * @param {(fullPath: string) => boolean} [options.filter] filter discovered files
  * @returns {AsyncIterableIterator<FileLike>}
  */
 async function * filesFromPath (filepath, options) {
@@ -93,7 +95,7 @@ async function * filesFromPath (filepath, options) {
   /** @param {string} filepath */
   const filter = filepath => {
     if (!hidden && path.basename(filepath).startsWith('.')) return false
-    return true
+    return !options || !options.filter || options.filter(filepath)
   }
 
   const name = filepath

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -67,6 +67,14 @@ test('allows read of more files than ulimit maxfiles', async t => {
   }
 })
 
+test('excludes files that do not match a filter', async (t) => {
+  const files = await filesFromPaths(['test/fixtures/dir/file2.txt', './test/fixtures/empty.car'], {
+    filter: (fullPath) => fullPath !== Path.resolve('./test/fixtures/empty.car')
+  })
+  t.is(files.length, 1)
+  t.is(files[0].name, 'file2.txt')
+})
+
 test('uses custom fs implementation', async t => {
   // it uses graceful-fs by default so passing node:fs is legit test
   const files = await filesFromPaths([`${process.cwd()}/test/fixtures`], { fs })

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -75,6 +75,14 @@ test('excludes files that do not match a filter', async (t) => {
   t.is(files[0].name, 'file2.txt')
 })
 
+test('excludes files that do not match a filter, in a directory', async (t) => {
+  const files = await filesFromPaths(['test/fixtures'], {
+    filter: (fullPath) => fullPath !== Path.resolve('./test/fixtures/empty.car') && fullPath !== Path.resolve('./test/fixtures/file.txt')
+  })
+  t.is(files.length, 1)
+  t.is(files[0].name, 'file2.txt')
+})
+
 test('uses custom fs implementation', async t => {
   // it uses graceful-fs by default so passing node:fs is legit test
   const files = await filesFromPaths([`${process.cwd()}/test/fixtures`], { fs })


### PR DESCRIPTION
# Goals

Solve an issue in ipfs-car when the destination car file is already present in the paths being packed

# Implementation

Can pass a filter function to filesFromPaths that must return true in order for a file to be included
